### PR TITLE
[Feat] BE - PDF 파싱 모듈 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+    // Apache PDFBox: Java에서 PDF 파일을 읽고 텍스트를 추출할 수 있게 해주는 라이브러리
+    implementation 'org.apache.pdfbox:pdfbox:3.0.3'
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/youthpolicy/ragchatbot/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.youthpolicy.ragchatbot.common.error;
 
 import com.youthpolicy.ragchatbot.documents.error.DocumentValidationException;
+import com.youthpolicy.ragchatbot.documents.parser.error.PdfParsingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -14,6 +15,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DocumentValidationException.class)
     public ResponseEntity<ApiErrorResponse> handleDocumentValidation(DocumentValidationException ex) {
         return ResponseEntity.badRequest().body(ApiErrorResponse.of(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(PdfParsingException.class)
+    public ResponseEntity<ApiErrorResponse> handlePdfParsing(PdfParsingException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiErrorResponse.of(ex.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler({MissingServletRequestPartException.class, MissingServletRequestParameterException.class})

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/parser/PdfBoxPdfParser.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/parser/PdfBoxPdfParser.java
@@ -1,0 +1,89 @@
+/* Pdf를 읽고 페이지별 텍스트를 추출한 뒤 그 결과를 ParsedPdfDocument DTO로 변환
+1. ParsedPdfPage 리스트에 페이지 번호 + 페이지 텍스트 저장
+2. fullText에 전체 페이지 텍스트 모두 저장
+3. 마지막으로 ParsePdfDocument DTO로 반환
+ */
+package com.youthpolicy.ragchatbot.documents.parser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.youthpolicy.ragchatbot.documents.parser.dto.ParsedPdfDocument;
+import com.youthpolicy.ragchatbot.documents.parser.dto.ParsedPdfPage;
+import com.youthpolicy.ragchatbot.documents.parser.error.PdfParsingException;
+
+@Component
+public class PdfBoxPdfParser implements PdfParser {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfBoxPdfParser.class);
+
+    @Override
+    public ParsedPdfDocument parse(MultipartFile file) {
+        // 직접 작성한 내부 검증 메서드
+        validatePdfFile(file);
+        // Spring StringUtils 유틸: 경로 조작 문자열 정리
+        String filename = StringUtils.cleanPath(file.getOriginalFilename());
+
+        // PDFBox Loader: 바이트 배열에서 PDF 문서 객체(PDDocument) 생성
+        try (PDDocument document = Loader.loadPDF(file.getBytes())) {
+            // PDFBox PDDocument: 총 페이지 수 조회
+            int totalPages = document.getNumberOfPages();
+            // PDFBox 텍스트 추출기
+            PDFTextStripper stripper = new PDFTextStripper(); //페이지별 텍스트 추출 도구 
+            List<ParsedPdfPage> pages = new ArrayList<>(totalPages);
+            StringBuilder fullText = new StringBuilder();
+
+            // 페이지별 결과와 전체 결과를 동시에 만드는 과정
+            for (int page = 1; page <= totalPages; page++) {
+                // PDFBox: 추출 시작/종료 페이지 지정 (한 페이지씩 추출)
+                stripper.setStartPage(page);
+                stripper.setEndPage(page);
+                // PDFBox: 지정 페이지 텍스트 추출
+                String pageText = normalizeText(stripper.getText(document));
+                pages.add(new ParsedPdfPage(page, pageText));
+
+                if (!pageText.isBlank()) {
+                    if (!fullText.isEmpty()) {
+                        fullText.append(System.lineSeparator());
+                    }
+                    fullText.append(pageText);
+                }
+            }
+
+            ParsedPdfDocument parsed = new ParsedPdfDocument(filename, totalPages, pages, fullText.toString());
+            log.info("PDF parsed successfully. file={}, pages={}, chars={}", filename, totalPages, parsed.fullText().length());
+            return parsed;
+        } catch (IOException ex) {
+            // PDF 로딩/파싱 관련 예외를 도메인 예외로 변환
+            log.error("Failed to parse PDF file. file={}", filename, ex);
+            throw new PdfParsingException("PDF_PARSE_FAILED", "PDF 파싱에 실패했습니다.");
+        }
+    }
+
+    private void validatePdfFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new PdfParsingException("PDF_FILE_REQUIRED", "PDF 파일이 필요합니다.");
+        }
+        String filename = file.getOriginalFilename();
+        if (!StringUtils.hasText(filename) || !filename.toLowerCase().endsWith(".pdf")) {
+            throw new PdfParsingException("PDF_FILE_REQUIRED", "PDF 파일만 파싱할 수 있습니다.");
+        }
+    }
+
+    private String normalizeText(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("\u0000", "").trim();
+    }
+}

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/parser/PdfParser.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/parser/PdfParser.java
@@ -1,0 +1,12 @@
+package com.youthpolicy.ragchatbot.documents.parser;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.youthpolicy.ragchatbot.documents.parser.dto.ParsedPdfDocument;
+
+// PDF 파싱 기능의 표준 계약(인터페이스). - 지금은 PdfBoxPdfParser를 쓰지만, 나중에 다른 파서 라이브러리로 바꾸기 쉬움
+// 실제 구현체(PDFBox 등)를 바꿔도 서비스 코드는 이 인터페이스만 의존하도록 분리한다.
+public interface PdfParser {
+    // 업로드된 PDF 파일을 받아 페이지별 텍스트/전체 텍스트를 반환한다.
+    ParsedPdfDocument parse(MultipartFile file);
+}

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/parser/dto/ParsedPdfDocument.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/parser/dto/ParsedPdfDocument.java
@@ -1,0 +1,11 @@
+package com.youthpolicy.ragchatbot.documents.parser.dto;
+
+import java.util.List;
+// PDF 전체 페이지 파싱 결과를 한 객체에 담는다.
+public record ParsedPdfDocument(
+        String filename,
+        int totalPages,
+        List<ParsedPdfPage> pages,
+        String fullText
+) {
+}

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/parser/dto/ParsedPdfPage.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/parser/dto/ParsedPdfPage.java
@@ -1,0 +1,7 @@
+package com.youthpolicy.ragchatbot.documents.parser.dto;
+// PDF 한 페이지 결과만 담는다.
+public record ParsedPdfPage(
+        int pageNumber,
+        String text
+) {
+}

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/parser/error/PdfParsingException.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/parser/error/PdfParsingException.java
@@ -1,0 +1,15 @@
+package com.youthpolicy.ragchatbot.documents.parser.error;
+
+public class PdfParsingException extends RuntimeException {
+
+    private final String code;
+
+    public PdfParsingException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/youthpolicy/ragchatbot/documents/service/DocumentUploadService.java
+++ b/src/main/java/com/youthpolicy/ragchatbot/documents/service/DocumentUploadService.java
@@ -2,15 +2,20 @@ package com.youthpolicy.ragchatbot.documents.service;
 
 import com.youthpolicy.ragchatbot.documents.dto.DocumentUploadResponse;
 import com.youthpolicy.ragchatbot.documents.error.DocumentValidationException;
+import com.youthpolicy.ragchatbot.documents.parser.PdfParser;
 import com.youthpolicy.ragchatbot.documents.repository.DocumentRepository;
 import java.util.Locale;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class DocumentUploadService implements DocumentService {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentUploadService.class);
 
     // 업로드 허용 확장자와 DB에 저장할 표준 Content-Type 매핑
     private static final Map<String, String> ALLOWED_EXTENSIONS = Map.of(
@@ -21,9 +26,11 @@ public class DocumentUploadService implements DocumentService {
     );
 
     private final DocumentRepository documentRepository;
+    private final PdfParser pdfParser;
 
-    public DocumentUploadService(DocumentRepository documentRepository) {
+    public DocumentUploadService(DocumentRepository documentRepository, PdfParser pdfParser) {
         this.documentRepository = documentRepository;
+        this.pdfParser = pdfParser;
     }
 
     @Override
@@ -35,6 +42,10 @@ public class DocumentUploadService implements DocumentService {
         String extension = getExtension(originalFilename);
         String contentType = ALLOWED_EXTENSIONS.get(extension);
         String title = extractTitle(originalFilename);
+        if ("pdf".equals(extension)) {
+            var parsed = pdfParser.parse(file);
+            log.info("Upload PDF parsed. file={}, pages={}", parsed.filename(), parsed.totalPages());
+        }
         // 3) 문서 메타데이터 저장 (실제 파일 저장/파싱은 다음 단계에서 처리)
         return documentRepository.insertUploadedDocument(title, originalFilename, contentType);
     }

--- a/src/test/java/com/youthpolicy/ragchatbot/documents/parser/PdfBoxPdfParserTest.java
+++ b/src/test/java/com/youthpolicy/ragchatbot/documents/parser/PdfBoxPdfParserTest.java
@@ -1,0 +1,103 @@
+package com.youthpolicy.ragchatbot.documents.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.youthpolicy.ragchatbot.documents.parser.error.PdfParsingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class PdfBoxPdfParserTest {
+
+    private final PdfBoxPdfParser parser = new PdfBoxPdfParser();
+
+    @Test
+    void parse_extractsTextForFiveSamplePdfs() throws IOException {
+        List<String> firstLines = List.of(
+                "youth-policy-sample-1",
+                "youth-policy-sample-2",
+                "youth-policy-sample-3",
+                "youth-policy-sample-4",
+                "youth-policy-sample-5"
+        );
+
+        for (int i = 0; i < firstLines.size(); i++) {
+            byte[] pdfBytes = createPdfBytes(List.of(firstLines.get(i)));
+            MockMultipartFile file = new MockMultipartFile(
+                    "file",
+                    "sample-" + (i + 1) + ".pdf",
+                    "application/pdf",
+                    pdfBytes
+            );
+
+            var parsed = parser.parse(file);
+
+            assertThat(parsed.totalPages()).isEqualTo(1);
+            assertThat(parsed.pages()).hasSize(1);
+            assertThat(parsed.pages().getFirst().pageNumber()).isEqualTo(1);
+            assertThat(parsed.pages().getFirst().text()).contains(firstLines.get(i));
+            assertThat(parsed.fullText()).contains(firstLines.get(i));
+        }
+    }
+
+    @Test
+    void parse_extractsTextByPage() throws IOException {
+        byte[] pdfBytes = createPdfBytes(List.of("first-page", "second-page"));
+        MockMultipartFile file = new MockMultipartFile("file", "multi-page.pdf", "application/pdf", pdfBytes);
+
+        var parsed = parser.parse(file);
+
+        assertThat(parsed.totalPages()).isEqualTo(2);
+        assertThat(parsed.pages()).hasSize(2);
+        assertThat(parsed.pages().get(0).pageNumber()).isEqualTo(1);
+        assertThat(parsed.pages().get(0).text()).contains("first-page");
+        assertThat(parsed.pages().get(1).pageNumber()).isEqualTo(2);
+        assertThat(parsed.pages().get(1).text()).contains("second-page");
+    }
+
+    @Test
+    void parse_throwsWhenInvalidPdf() {
+        MockMultipartFile file = new MockMultipartFile("file", "broken.pdf", "application/pdf", "not-a-pdf".getBytes());
+
+        assertThatThrownBy(() -> parser.parse(file))
+                .isInstanceOf(PdfParsingException.class)
+                .hasMessageContaining("PDF 파싱");
+    }
+
+    @Test
+    void parse_throwsWhenExtensionIsNotPdf() {
+        MockMultipartFile file = new MockMultipartFile("file", "note.txt", "text/plain", "text".getBytes());
+
+        assertThatThrownBy(() -> parser.parse(file))
+                .isInstanceOf(PdfParsingException.class)
+                .hasMessageContaining("PDF 파일만");
+    }
+
+    private byte[] createPdfBytes(List<String> pageTexts) throws IOException {
+        try (PDDocument document = new PDDocument();
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDType1Font font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+            for (String pageText : pageTexts) {
+                PDPage page = new PDPage();
+                document.addPage(page);
+                try (PDPageContentStream stream = new PDPageContentStream(document, page)) {
+                    stream.beginText();
+                    stream.setFont(font, 12);
+                    stream.newLineAtOffset(72, 720);
+                    stream.showText(pageText);
+                    stream.endText();
+                }
+            }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/src/test/java/com/youthpolicy/ragchatbot/documents/service/DocumentUploadServiceTest.java
+++ b/src/test/java/com/youthpolicy/ragchatbot/documents/service/DocumentUploadServiceTest.java
@@ -3,12 +3,17 @@ package com.youthpolicy.ragchatbot.documents.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.youthpolicy.ragchatbot.documents.dto.DocumentUploadResponse;
 import com.youthpolicy.ragchatbot.documents.error.DocumentValidationException;
+import com.youthpolicy.ragchatbot.documents.parser.PdfParser;
+import com.youthpolicy.ragchatbot.documents.parser.dto.ParsedPdfDocument;
+import com.youthpolicy.ragchatbot.documents.parser.dto.ParsedPdfPage;
 import com.youthpolicy.ragchatbot.documents.repository.DocumentRepository;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +27,9 @@ class DocumentUploadServiceTest {
     @Mock
     private DocumentRepository documentRepository;
 
+    @Mock
+    private PdfParser pdfParser;
+
     @InjectMocks
     private DocumentUploadService documentUploadService;
 
@@ -32,6 +40,7 @@ class DocumentUploadServiceTest {
         assertThatThrownBy(() -> documentUploadService.upload(file))
                 .isInstanceOf(DocumentValidationException.class)
                 .hasMessageContaining("빈 파일");
+        verifyNoInteractions(pdfParser, documentRepository);
     }
 
     @Test
@@ -41,6 +50,7 @@ class DocumentUploadServiceTest {
         assertThatThrownBy(() -> documentUploadService.upload(file))
                 .isInstanceOf(DocumentValidationException.class)
                 .hasMessageContaining("지원하지 않는 파일 형식");
+        verifyNoInteractions(pdfParser, documentRepository);
     }
 
     @Test
@@ -58,9 +68,16 @@ class DocumentUploadServiceTest {
         );
         when(documentRepository.insertUploadedDocument(eq("policy-guide"), eq("policy-guide.pdf"), eq("application/pdf")))
                 .thenReturn(response);
+        when(pdfParser.parse(file)).thenReturn(new ParsedPdfDocument(
+                "policy-guide.pdf",
+                1,
+                List.of(new ParsedPdfPage(1, "content")),
+                "content"
+        ));
 
         documentUploadService.upload(file);
 
+        verify(pdfParser).parse(file);
         verify(documentRepository).insertUploadedDocument(eq("policy-guide"), eq("policy-guide.pdf"), eq("application/pdf"));
     }
 
@@ -88,6 +105,7 @@ class DocumentUploadServiceTest {
 
         documentUploadService.upload(file);
 
+        verifyNoInteractions(pdfParser);
         verify(documentRepository).insertUploadedDocument(eq("youth-policy"), eq("youth-policy.docx"), eq(expectedContentType));
     }
 }


### PR DESCRIPTION
## 🧾 Youth-Policy RAG Chatbot

## ✏️ Summary
PDF 파싱 모듈 구현을 진행했습니다.  
Apache PDFBox 기반 파서를 추가하고, PDF 업로드 시 페이지별 텍스트/전체 텍스트를 추출하도록 연동했습니다.  
파싱 실패 예외를 분리해 API 응답 코드로 일관 처리하도록 구성했습니다.  
Closes: #4 

## 📢 Motivation
정책 PDF를 안정적으로 텍스트로 추출해야 이후 청킹과 임베딩으로 연결할 수 있습니다.  
문서 업로드 기능 이후, 실제 RAG 파이프라인의 입력을 만드는 단계가 필요했습니다.

## 📌 Type of Change
- [x] ✨ New Feature / 새로운 기능
- [ ] 🐞 Bug Fix / 버그 수정
- [ ] 💅 Style / UI Update / 스타일·UI 변경
- [ ] 🧹 Refactor (non-breaking) / 리팩토링(비호환X)
- [ ] 🧾 Docs / 문서
- [x] ✅ Test Added / Updated / 테스트 추가·수정
- [x] ⚙️ Build / CI / Config / 빌드·CI·설정
- [ ] 🔥 Breaking Change / 호환성 깨짐
- [ ] ♻️ Other / 기타 (설명)

## 🛠️ Implementation Details
- `build.gradle`
  - `org.apache.pdfbox:pdfbox:3.0.3` 추가
- PDF 파서 모듈 추가
  - `PdfParser` 인터페이스
  - `PdfBoxPdfParser` 구현체
  - `ParsedPdfDocument`, `ParsedPdfPage` DTO
  - `PdfParsingException` 추가
- 업로드 서비스 연동
  - `DocumentUploadService`에 `PdfParser` 주입
  - 확장자가 `pdf`인 경우 파싱 실행
- 예외 처리 보강
  - `GlobalExceptionHandler`에 `PdfParsingException -> 422` 처리 추가
- 테스트 보강
  - `PdfBoxPdfParserTest` 추가
    - 샘플 PDF 5개 파싱 성공
    - 페이지별 텍스트 추출 검증
    - 비정상 PDF/비PDF 입력 실패 검증
  - `DocumentUploadServiceTest` 업데이트 (PDF 파서 연동 검증)

## 🧪 Testing
- `./gradlew test` 통과
- `./gradlew bootRun` 실행 후 수동 확인
  - 정상 PDF 업로드 시 파싱/저장 성공
  - 손상된 PDF 업로드 시 `422` (`PDF_PARSE_FAILED`)
  - 미지원 확장자 업로드 시 `400` (`UNSUPPORTED_FILE_TYPE`)

## 🖼️ Screenshots / Demos
<img width="2460" height="156" alt="image" src="https://github.com/user-attachments/assets/616f4add-cab5-4769-802d-e579e2fe0192" />

## ✅ Checklist
- [x] Tests pass locally / 로컬 테스트 통과
- [ ] Lint & type checks pass / 린트·타입체크 통과
- [ ] Docs updated if needed / 필요 시 문서 업데이트
- [x] Commit messages follow convention / 커밋 규칙 준수
